### PR TITLE
Add SULO ontology to registry

### DIFF
--- a/ontologies.Makefile
+++ b/ontologies.Makefile
@@ -1637,6 +1637,17 @@ db/minsysont.owl: download/minsysont.owl
 	robot merge -i $< -o $@.tmp.owl && perl -npe 's/\[HSiO4\]/%5BHSiO4%5D/g' $@.tmp.owl > $@ && rm $@.tmp.owl
 
 
+download/sulo.owl: STAMP
+	curl -L -s https://w3id.org/sulo/sulo.ttl > $@.tmp
+	sha256sum -b $@.tmp > $@.sha256
+	mv $@.tmp $@
+
+.PRECIOUS: download/sulo.owl
+
+db/sulo.owl: download/sulo.owl
+	robot merge -i $< -o $@
+
+
 download/%.owl: STAMP
 	curl -L -s http://purl.obolibrary.org/obo/$*.owl > $@.tmp
 	sha256sum -b $@.tmp > $@.sha256
@@ -1647,4 +1658,4 @@ download/%.owl: STAMP
 db/%.owl: download/%.owl
 	robot merge -i $< -o $@
 
-EXTRA_ONTOLOGIES = swo chiro pcl chemessence ogco ncit fma maxo foodon chebiplus msio chemrof deb matpo panet phenx pride sosa emi npc modl phenio comploinc hba mba dmba dhba pba bero aio reacto xsmo bcio sio icd10who icd11f ordo gard icd10cm omim mondo-ingest oeo envthes wifire taxslim goldterms sdgio kin metpo d3o biovoices omop comet cco occo iof upa go go-lego go-amigo neo bao orcid ror cpont biolink biopax enanomapper mlo ito chemont molgenie cso obiws biopragmatics-reactome reactome-hs reactome-mm efo hcao hpinternational edam chr sweetAll oboe-core oboe-standards lov schema-dot-org prov dtype vaem qudtunit quantitykind cellosaurus cosmo gist gistBFO fhkb dbpendiaont uberoncm co_324 ppeo interpro pfam hgnc.genegroup hgnc sgd gtdb eccode uniprot uniprot.ptm credit rhea swisslipid drugbank drugcentral complexportal wikipathways pathbank kegg.genome drugmechdb rxnorm vccf ontobiotope nando ecso enigma_context cbo ontie pain como ecosim bervo valuesets micront nmdc_schema mixs kgcl fibo bfo2020 bfo2020_core bfo2020_notime bfo2020_time saref4ener saref4bldg hhearvs sdoho pathgo brick minsysont
+EXTRA_ONTOLOGIES = swo chiro pcl chemessence ogco ncit fma maxo foodon chebiplus msio chemrof deb matpo panet phenx pride sosa emi npc modl phenio comploinc hba mba dmba dhba pba bero aio reacto xsmo bcio sio icd10who icd11f ordo gard icd10cm omim mondo-ingest oeo envthes wifire taxslim goldterms sdgio kin metpo d3o biovoices omop comet cco occo iof upa go go-lego go-amigo neo bao orcid ror cpont biolink biopax enanomapper mlo ito chemont molgenie cso obiws biopragmatics-reactome reactome-hs reactome-mm efo hcao hpinternational edam chr sweetAll oboe-core oboe-standards lov schema-dot-org prov dtype vaem qudtunit quantitykind cellosaurus cosmo gist gistBFO fhkb dbpendiaont uberoncm co_324 ppeo interpro pfam hgnc.genegroup hgnc sgd gtdb eccode uniprot uniprot.ptm credit rhea swisslipid drugbank drugcentral complexportal wikipathways pathbank kegg.genome drugmechdb rxnorm vccf ontobiotope nando ecso enigma_context cbo ontie pain como ecosim bervo valuesets micront nmdc_schema mixs kgcl fibo bfo2020 bfo2020_core bfo2020_notime bfo2020_time saref4ener saref4bldg hhearvs sdoho pathgo brick minsysont sulo

--- a/src/semsql/builder/prefixes/prefixes.csv
+++ b/src/semsql/builder/prefixes/prefixes.csv
@@ -252,6 +252,7 @@ sh,http://www.w3.org/ns/shacl#
 vcard,http://www.w3.org/2006/vcard/ns#
 MinSysOnt,http://www.semanticweb.org/hbabaie/ontologies/2021/5/MinSysOnt#
 CMO.minerals,http://www.semanticweb.org/Davarpanah-Babaie/Ontologies/2022/CMO#
+sulo,https://w3id.org/sulo/
 RBO,http://purl.obolibrary.org/obo/RBO_
 RBO,http://purl.obolibrary.org/obo/RBO_
 CLYH,http://purl.obolibrary.org/obo/CLYH_

--- a/src/semsql/builder/prefixes/prefixes_local.csv
+++ b/src/semsql/builder/prefixes/prefixes_local.csv
@@ -189,3 +189,4 @@ sh,http://www.w3.org/ns/shacl#
 vcard,http://www.w3.org/2006/vcard/ns#
 MinSysOnt,http://www.semanticweb.org/hbabaie/ontologies/2021/5/MinSysOnt#
 CMO.minerals,http://www.semanticweb.org/Davarpanah-Babaie/Ontologies/2022/CMO#
+sulo,https://w3id.org/sulo/

--- a/src/semsql/builder/registry/ontologies.yaml
+++ b/src/semsql/builder/registry/ontologies.yaml
@@ -764,3 +764,9 @@ ontologies:
     prefixmap:
       MinSysOnt: "http://www.semanticweb.org/hbabaie/ontologies/2021/5/MinSysOnt#"
       CMO.minerals: "http://www.semanticweb.org/Davarpanah-Babaie/Ontologies/2022/CMO#"
+  sulo:
+    description: Simplified Upper Level Ontology
+    url: https://w3id.org/sulo/sulo.ttl
+    format: turtle
+    prefixmap:
+      sulo: https://w3id.org/sulo/


### PR DESCRIPTION
## Summary
- Add `sulo` to `src/semsql/builder/registry/ontologies.yaml`
  - `url: https://w3id.org/sulo/sulo.ttl`
  - `format: turtle`
  - `prefixmap: sulo -> https://w3id.org/sulo/`
- Regenerate derived files updated by registry compilation:
  - `ontologies.Makefile`
  - `src/semsql/builder/prefixes/prefixes_local.csv`
  - `src/semsql/builder/prefixes/prefixes.csv`

## Validation
- `uv run semsql generate-makefile -P src/semsql/builder/prefixes/prefixes_local.csv src/semsql/builder/registry/ontologies.yaml`
- `uv run python` check for `get_postprocessing_steps('sulo', 'db/sulo.db')`
- Verified generated makefile includes `download/sulo.owl` and `sulo` in `EXTRA_ONTOLOGIES`