### PR TITLE
[codex] Add initial ENERO registry entries

### DIFF
--- a/ontologies.Makefile
+++ b/ontologies.Makefile
@@ -460,6 +460,28 @@ db/oeo.owl: download/oeo.owl
 	cp $< $@
 
 
+download/cepo.owl: STAMP
+	curl -L -s https://raw.githubusercontent.com/OpenEnergyPlatform/ClimateEnergyPolicyOntology/production/src/ontology/cepo.owl > $@.tmp
+	sha256sum -b $@.tmp > $@.sha256
+	mv $@.tmp $@
+
+.PRECIOUS: download/cepo.owl
+
+db/cepo.owl: download/cepo.owl
+	robot merge -i $< -o $@
+
+
+download/oto.owl: STAMP
+	curl -L -s https://raw.githubusercontent.com/OpenEnergyPlatform/OpenTransportOntology/production/src/ontology/oto.ttl > $@.tmp
+	sha256sum -b $@.tmp > $@.sha256
+	mv $@.tmp $@
+
+.PRECIOUS: download/oto.owl
+
+db/oto.owl: download/oto.owl
+	perl -0pe 's@http://w3id.org/oto/develop/oto-shared.ttl@https://raw.githubusercontent.com/OpenEnergyPlatform/OpenTransportOntology/production/src/ontology/edits/oto-shared.ttl@g' $< > $@.tmp.ttl && robot merge -i $@.tmp.ttl -o $@ && rm $@.tmp.ttl
+
+
 download/envthes.owl: STAMP
 	curl -L -s https://vocabs.lter-europe.net/rest/v1/envthes/data?format=text/turtle > $@.tmp
 	sha256sum -b $@.tmp > $@.sha256
@@ -1658,4 +1680,4 @@ download/%.owl: STAMP
 db/%.owl: download/%.owl
 	robot merge -i $< -o $@
 
-EXTRA_ONTOLOGIES = swo chiro pcl chemessence ogco ncit fma maxo foodon chebiplus msio chemrof deb matpo panet phenx pride sosa emi npc modl phenio comploinc hba mba dmba dhba pba bero aio reacto xsmo bcio sio icd10who icd11f ordo gard icd10cm omim mondo-ingest oeo envthes wifire taxslim goldterms sdgio kin metpo d3o biovoices omop comet cco occo iof upa go go-lego go-amigo neo bao orcid ror cpont biolink biopax enanomapper mlo ito chemont molgenie cso obiws biopragmatics-reactome reactome-hs reactome-mm efo hcao hpinternational edam chr sweetAll oboe-core oboe-standards lov schema-dot-org prov dtype vaem qudtunit quantitykind cellosaurus cosmo gist gistBFO fhkb dbpendiaont uberoncm co_324 ppeo interpro pfam hgnc.genegroup hgnc sgd gtdb eccode uniprot uniprot.ptm credit rhea swisslipid drugbank drugcentral complexportal wikipathways pathbank kegg.genome drugmechdb rxnorm vccf ontobiotope nando ecso enigma_context cbo ontie pain como ecosim bervo valuesets micront nmdc_schema mixs kgcl fibo bfo2020 bfo2020_core bfo2020_notime bfo2020_time saref4ener saref4bldg hhearvs sdoho pathgo brick minsysont sulo
+EXTRA_ONTOLOGIES = swo chiro pcl chemessence ogco ncit fma maxo foodon chebiplus msio chemrof deb matpo panet phenx pride sosa emi npc modl phenio comploinc hba mba dmba dhba pba bero aio reacto xsmo bcio sio icd10who icd11f ordo gard icd10cm omim mondo-ingest oeo cepo oto envthes wifire taxslim goldterms sdgio kin metpo d3o biovoices omop comet cco occo iof upa go go-lego go-amigo neo bao orcid ror cpont biolink biopax enanomapper mlo ito chemont molgenie cso obiws biopragmatics-reactome reactome-hs reactome-mm efo hcao hpinternational edam chr sweetAll oboe-core oboe-standards lov schema-dot-org prov dtype vaem qudtunit quantitykind cellosaurus cosmo gist gistBFO fhkb dbpendiaont uberoncm co_324 ppeo interpro pfam hgnc.genegroup hgnc sgd gtdb eccode uniprot uniprot.ptm credit rhea swisslipid drugbank drugcentral complexportal wikipathways pathbank kegg.genome drugmechdb rxnorm vccf ontobiotope nando ecso enigma_context cbo ontie pain como ecosim bervo valuesets micront nmdc_schema mixs kgcl fibo bfo2020 bfo2020_core bfo2020_notime bfo2020_time saref4ener saref4bldg hhearvs sdoho pathgo brick minsysont sulo

--- a/ontologies.Makefile
+++ b/ontologies.Makefile
@@ -482,6 +482,28 @@ db/oto.owl: download/oto.owl
 	perl -0pe 's@http://w3id.org/oto/develop/oto-shared.ttl@https://raw.githubusercontent.com/OpenEnergyPlatform/OpenTransportOntology/production/src/ontology/edits/oto-shared.ttl@g' $< > $@.tmp.ttl && robot merge -i $@.tmp.ttl -o $@ && rm $@.tmp.ttl
 
 
+download/meno.owl: STAMP
+	curl -L -s https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl > $@.tmp
+	sha256sum -b $@.tmp > $@.sha256
+	mv $@.tmp $@
+
+.PRECIOUS: download/meno.owl
+
+db/meno.owl: download/meno.owl
+	robot merge -i $< -o $@
+
+
+download/muno.owl: STAMP
+	curl -L -s https://raw.githubusercontent.com/stap-m/muno/main/src/muno.owl > $@.tmp
+	sha256sum -b $@.tmp > $@.sha256
+	mv $@.tmp $@
+
+.PRECIOUS: download/muno.owl
+
+db/muno.owl: download/muno.owl
+	perl -0pe 's@http://www.semanticweb.org/abc/ontologies/2025/2/untitled-ontology-46/@https://raw.githubusercontent.com/stap-m/muno/main/src/ro-extracted.owl@g; s@http://www.semanticweb.org/abc/ontologies/2025/2/untitled-ontology-47/@https://raw.githubusercontent.com/stap-m/muno/main/src/iao-extracted.owl@g' $< > $@.tmp.owl && robot merge -i $@.tmp.owl -o $@ && rm $@.tmp.owl
+
+
 download/envthes.owl: STAMP
 	curl -L -s https://vocabs.lter-europe.net/rest/v1/envthes/data?format=text/turtle > $@.tmp
 	sha256sum -b $@.tmp > $@.sha256
@@ -1680,4 +1702,4 @@ download/%.owl: STAMP
 db/%.owl: download/%.owl
 	robot merge -i $< -o $@
 
-EXTRA_ONTOLOGIES = swo chiro pcl chemessence ogco ncit fma maxo foodon chebiplus msio chemrof deb matpo panet phenx pride sosa emi npc modl phenio comploinc hba mba dmba dhba pba bero aio reacto xsmo bcio sio icd10who icd11f ordo gard icd10cm omim mondo-ingest oeo cepo oto envthes wifire taxslim goldterms sdgio kin metpo d3o biovoices omop comet cco occo iof upa go go-lego go-amigo neo bao orcid ror cpont biolink biopax enanomapper mlo ito chemont molgenie cso obiws biopragmatics-reactome reactome-hs reactome-mm efo hcao hpinternational edam chr sweetAll oboe-core oboe-standards lov schema-dot-org prov dtype vaem qudtunit quantitykind cellosaurus cosmo gist gistBFO fhkb dbpendiaont uberoncm co_324 ppeo interpro pfam hgnc.genegroup hgnc sgd gtdb eccode uniprot uniprot.ptm credit rhea swisslipid drugbank drugcentral complexportal wikipathways pathbank kegg.genome drugmechdb rxnorm vccf ontobiotope nando ecso enigma_context cbo ontie pain como ecosim bervo valuesets micront nmdc_schema mixs kgcl fibo bfo2020 bfo2020_core bfo2020_notime bfo2020_time saref4ener saref4bldg hhearvs sdoho pathgo brick minsysont sulo
+EXTRA_ONTOLOGIES = swo chiro pcl chemessence ogco ncit fma maxo foodon chebiplus msio chemrof deb matpo panet phenx pride sosa emi npc modl phenio comploinc hba mba dmba dhba pba bero aio reacto xsmo bcio sio icd10who icd11f ordo gard icd10cm omim mondo-ingest oeo cepo oto meno muno envthes wifire taxslim goldterms sdgio kin metpo d3o biovoices omop comet cco occo iof upa go go-lego go-amigo neo bao orcid ror cpont biolink biopax enanomapper mlo ito chemont molgenie cso obiws biopragmatics-reactome reactome-hs reactome-mm efo hcao hpinternational edam chr sweetAll oboe-core oboe-standards lov schema-dot-org prov dtype vaem qudtunit quantitykind cellosaurus cosmo gist gistBFO fhkb dbpendiaont uberoncm co_324 ppeo interpro pfam hgnc.genegroup hgnc sgd gtdb eccode uniprot uniprot.ptm credit rhea swisslipid drugbank drugcentral complexportal wikipathways pathbank kegg.genome drugmechdb rxnorm vccf ontobiotope nando ecso enigma_context cbo ontie pain como ecosim bervo valuesets micront nmdc_schema mixs kgcl fibo bfo2020 bfo2020_core bfo2020_notime bfo2020_time saref4ener saref4bldg hhearvs sdoho pathgo brick minsysont sulo

--- a/src/semsql/builder/prefixes/prefixes.csv
+++ b/src/semsql/builder/prefixes/prefixes.csv
@@ -117,6 +117,8 @@ OEO,https://openenergyplatform.org/ontology/oeo/OEO_
 OEOX,https://openenergyplatform.org/ontology/oeo/OEOX_
 MENO,https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_
 OEO.CCO,http://www.ontologyrepository.com/CommonCoreOntologies/
+CEPO,http://purl.org/cepo/ontology#cepo_
+OTO,http://w3id.org/oto/OTO_
 envthes,http://vocabs.lter-europe.net/EnvThes/
 omv,http://omv.ontoware.org/2005/05/
 iadopt,https://w3id.org/iadopt/ont/

--- a/src/semsql/builder/prefixes/prefixes.csv
+++ b/src/semsql/builder/prefixes/prefixes.csv
@@ -115,10 +115,11 @@ OMIM,https://omim.org/entry/
 OMIMPS,https://omim.org/phenotypicSeries/PS
 OEO,https://openenergyplatform.org/ontology/oeo/OEO_
 OEOX,https://openenergyplatform.org/ontology/oeo/OEOX_
-MENO,https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_
 OEO.CCO,http://www.ontologyrepository.com/CommonCoreOntologies/
 CEPO,http://purl.org/cepo/ontology#cepo_
 OTO,http://w3id.org/oto/OTO_
+MENO,https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_
+MUNO,https://raw.githubusercontent.com/stap-m/muno/main/src/muno.owl/MUNO_
 envthes,http://vocabs.lter-europe.net/EnvThes/
 omv,http://omv.ontoware.org/2005/05/
 iadopt,https://w3id.org/iadopt/ont/

--- a/src/semsql/builder/prefixes/prefixes_local.csv
+++ b/src/semsql/builder/prefixes/prefixes_local.csv
@@ -54,6 +54,8 @@ OEO,https://openenergyplatform.org/ontology/oeo/OEO_
 OEOX,https://openenergyplatform.org/ontology/oeo/OEOX_
 MENO,https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_
 OEO.CCO,http://www.ontologyrepository.com/CommonCoreOntologies/
+CEPO,http://purl.org/cepo/ontology#cepo_
+OTO,http://w3id.org/oto/OTO_
 envthes,http://vocabs.lter-europe.net/EnvThes/
 omv,http://omv.ontoware.org/2005/05/
 iadopt,https://w3id.org/iadopt/ont/

--- a/src/semsql/builder/prefixes/prefixes_local.csv
+++ b/src/semsql/builder/prefixes/prefixes_local.csv
@@ -52,10 +52,11 @@ OMIM,https://omim.org/entry/
 OMIMPS,https://omim.org/phenotypicSeries/PS
 OEO,https://openenergyplatform.org/ontology/oeo/OEO_
 OEOX,https://openenergyplatform.org/ontology/oeo/OEOX_
-MENO,https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_
 OEO.CCO,http://www.ontologyrepository.com/CommonCoreOntologies/
 CEPO,http://purl.org/cepo/ontology#cepo_
 OTO,http://w3id.org/oto/OTO_
+MENO,https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_
+MUNO,https://raw.githubusercontent.com/stap-m/muno/main/src/muno.owl/MUNO_
 envthes,http://vocabs.lter-europe.net/EnvThes/
 omv,http://omv.ontoware.org/2005/05/
 iadopt,https://w3id.org/iadopt/ont/

--- a/src/semsql/builder/registry/ontologies.yaml
+++ b/src/semsql/builder/registry/ontologies.yaml
@@ -215,6 +215,9 @@ ontologies:
     url: https://raw.githubusercontent.com/OpenEnergyPlatform/OpenTransportOntology/production/src/ontology/oto.ttl
     has_imports: true
     format: turtle
+    # Temporary workaround: the published import target `http://w3id.org/oto/develop/oto-shared.ttl`
+    # currently resolves to HTML docs instead of RDF/Turtle.
+    # Upstream issue: https://github.com/OpenEnergyPlatform/OpenTransportOntology/issues/46
     build_command: "perl -0pe 's@http://w3id.org/oto/develop/oto-shared.ttl@https://raw.githubusercontent.com/OpenEnergyPlatform/OpenTransportOntology/production/src/ontology/edits/oto-shared.ttl@g' $< > $@.tmp.ttl && robot merge -i $@.tmp.ttl -o $@ && rm $@.tmp.ttl"
     prefixmap:
       OTO: http://w3id.org/oto/OTO_

--- a/src/semsql/builder/registry/ontologies.yaml
+++ b/src/semsql/builder/registry/ontologies.yaml
@@ -204,7 +204,6 @@ ontologies:
       # https://github.com/OpenEnergyPlatform/ontology/pull/2050
       OEO: https://openenergyplatform.org/ontology/oeo/OEO_
       OEOX: https://openenergyplatform.org/ontology/oeo/OEOX_
-      MENO: https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_
       OEO.CCO: http://www.ontologyrepository.com/CommonCoreOntologies/
   cepo:
     url: https://raw.githubusercontent.com/OpenEnergyPlatform/ClimateEnergyPolicyOntology/production/src/ontology/cepo.owl
@@ -221,6 +220,21 @@ ontologies:
     build_command: "perl -0pe 's@http://w3id.org/oto/develop/oto-shared.ttl@https://raw.githubusercontent.com/OpenEnergyPlatform/OpenTransportOntology/production/src/ontology/edits/oto-shared.ttl@g' $< > $@.tmp.ttl && robot merge -i $@.tmp.ttl -o $@ && rm $@.tmp.ttl"
     prefixmap:
       OTO: http://w3id.org/oto/OTO_
+  meno:
+    url: https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl
+    has_imports: true
+    prefixmap:
+      MENO: https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_
+  muno:
+    url: https://raw.githubusercontent.com/stap-m/muno/main/src/muno.owl
+    has_imports: true
+    # Temporary workaround: the published OWL imports two placeholder
+    # `semanticweb.org/.../untitled-ontology-*` IRIs that are only resolved via
+    # the repo-local Protégé catalog. Rewrite them to the raw extracted imports.
+    # Upstream issue: https://github.com/stap-m/muno/issues/6
+    build_command: "perl -0pe 's@http://www.semanticweb.org/abc/ontologies/2025/2/untitled-ontology-46/@https://raw.githubusercontent.com/stap-m/muno/main/src/ro-extracted.owl@g; s@http://www.semanticweb.org/abc/ontologies/2025/2/untitled-ontology-47/@https://raw.githubusercontent.com/stap-m/muno/main/src/iao-extracted.owl@g' $< > $@.tmp.owl && robot merge -i $@.tmp.owl -o $@ && rm $@.tmp.owl"
+    prefixmap:
+      MUNO: https://raw.githubusercontent.com/stap-m/muno/main/src/muno.owl/MUNO_
   envthes:
     url: https://vocabs.lter-europe.net/rest/v1/envthes/data?format=text/turtle
     build_command: "robot query -i $< --update sparql/skos-to-owl.ru -o $@"

--- a/src/semsql/builder/registry/ontologies.yaml
+++ b/src/semsql/builder/registry/ontologies.yaml
@@ -196,6 +196,7 @@ ontologies:
       OMIMPS: https://omim.org/phenotypicSeries/PS
   mondo-ingest:
     url: https://github.com/monarch-initiative/mondo-ingest/releases/latest/download/mondo-ingest.owl
+  # ENERO Foundry / Open Energy Family ontologies
   oeo:
     url: https://openenergyplatform.org/ontology/oeo/releases/oeo-full.owl
     prefixmap:
@@ -205,6 +206,18 @@ ontologies:
       OEOX: https://openenergyplatform.org/ontology/oeo/OEOX_
       MENO: https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_
       OEO.CCO: http://www.ontologyrepository.com/CommonCoreOntologies/
+  cepo:
+    url: https://raw.githubusercontent.com/OpenEnergyPlatform/ClimateEnergyPolicyOntology/production/src/ontology/cepo.owl
+    has_imports: true
+    prefixmap:
+      CEPO: http://purl.org/cepo/ontology#cepo_
+  oto:
+    url: https://raw.githubusercontent.com/OpenEnergyPlatform/OpenTransportOntology/production/src/ontology/oto.ttl
+    has_imports: true
+    format: turtle
+    build_command: "perl -0pe 's@http://w3id.org/oto/develop/oto-shared.ttl@https://raw.githubusercontent.com/OpenEnergyPlatform/OpenTransportOntology/production/src/ontology/edits/oto-shared.ttl@g' $< > $@.tmp.ttl && robot merge -i $@.tmp.ttl -o $@ && rm $@.tmp.ttl"
+    prefixmap:
+      OTO: http://w3id.org/oto/OTO_
   envthes:
     url: https://vocabs.lter-europe.net/rest/v1/envthes/data?format=text/turtle
     build_command: "robot query -i $< --update sparql/skos-to-owl.ru -o $@"

--- a/tests/test_builder/test_registry.py
+++ b/tests/test_builder/test_registry.py
@@ -1,3 +1,9 @@
+"""Registry compilation tests.
+
+These tests only verify that ontology registry entries compile into the expected
+download/build rules. They are not end-to-end ontology build tests.
+"""
+
 import re
 
 import pytest

--- a/tests/test_builder/test_registry.py
+++ b/tests/test_builder/test_registry.py
@@ -25,6 +25,14 @@ def registry_makefile() -> str:
             "https://raw.githubusercontent.com/OpenEnergyPlatform/ClimateEnergyPolicyOntology/production/src/ontology/cepo.owl",
         ),
         (
+            "meno",
+            "https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl",
+        ),
+        (
+            "muno",
+            "https://raw.githubusercontent.com/stap-m/muno/main/src/muno.owl",
+        ),
+        (
             "oto",
             "https://raw.githubusercontent.com/OpenEnergyPlatform/OpenTransportOntology/production/src/ontology/oto.ttl",
         ),
@@ -39,6 +47,11 @@ def test_enero_download_rules_present(registry_makefile: str, ontology_id: str, 
     ("ontology_id", "command"),
     [
         ("cepo", r"robot merge -i \$< -o \$@"),
+        ("meno", r"robot merge -i \$< -o \$@"),
+        (
+            "muno",
+            r"perl -0pe 's@http://www\.semanticweb\.org/abc/ontologies/2025/2/untitled-ontology-46/@https://raw\.githubusercontent\.com/stap-m/muno/main/src/ro-extracted\.owl@g; s@http://www\.semanticweb\.org/abc/ontologies/2025/2/untitled-ontology-47/@https://raw\.githubusercontent\.com/stap-m/muno/main/src/iao-extracted\.owl@g' \$< > \$@\.tmp\.owl && robot merge -i \$@\.tmp\.owl -o \$@ && rm \$@\.tmp\.owl",
+        ),
         (
             "oto",
             r"perl -0pe 's@http://w3id.org/oto/develop/oto-shared.ttl@https://raw.githubusercontent.com/OpenEnergyPlatform/OpenTransportOntology/production/src/ontology/edits/oto-shared.ttl@g' \$< > \$@\.tmp\.ttl && robot merge -i \$@\.tmp\.ttl -o \$@ && rm \$@\.tmp\.ttl",

--- a/tests/test_builder/test_registry.py
+++ b/tests/test_builder/test_registry.py
@@ -1,0 +1,46 @@
+import re
+
+import pytest
+
+from semsql.builder import builder
+from semsql.builder.registry import path_to_ontology_registry
+
+
+@pytest.fixture(scope="module")
+def registry_makefile() -> str:
+    return builder.compile_registry(str(path_to_ontology_registry()))
+
+
+@pytest.mark.parametrize(
+    ("ontology_id", "url"),
+    [
+        (
+            "cepo",
+            "https://raw.githubusercontent.com/OpenEnergyPlatform/ClimateEnergyPolicyOntology/production/src/ontology/cepo.owl",
+        ),
+        (
+            "oto",
+            "https://raw.githubusercontent.com/OpenEnergyPlatform/OpenTransportOntology/production/src/ontology/oto.ttl",
+        ),
+    ],
+)
+def test_enero_download_rules_present(registry_makefile: str, ontology_id: str, url: str):
+    assert f"download/{ontology_id}.owl: STAMP" in registry_makefile
+    assert f"curl -L -s {url} > $@.tmp" in registry_makefile
+
+
+@pytest.mark.parametrize(
+    ("ontology_id", "command"),
+    [
+        ("cepo", r"robot merge -i \$< -o \$@"),
+        (
+            "oto",
+            r"perl -0pe 's@http://w3id.org/oto/develop/oto-shared.ttl@https://raw.githubusercontent.com/OpenEnergyPlatform/OpenTransportOntology/production/src/ontology/edits/oto-shared.ttl@g' \$< > \$@\.tmp\.ttl && robot merge -i \$@\.tmp\.ttl -o \$@ && rm \$@\.tmp\.ttl",
+        ),
+    ],
+)
+def test_enero_build_rules_present(
+    registry_makefile: str, ontology_id: str, command: str
+):
+    pattern = rf"db/{ontology_id}\.owl: download/{ontology_id}\.owl\n\t{command}"
+    assert re.search(pattern, registry_makefile)


### PR DESCRIPTION
## Summary
Adds an initial ENERO Foundry integration slice to the SemSQL ontology registry.

This PR adds:
- `cepo` as a registry entry backed by the upstream production OWL artifact
- `oto` as a registry entry backed by the upstream production Turtle artifact
- a focused registry-generation test covering the new download/build rules

## Why
Issue #107 tracks broader ENERO ontology onboarding.

This PR intentionally starts with the ontologies that have publicly reachable machine-readable sources and can be wired into the existing SemSQL registry model with minimal surface area.

## Notes
- `cepo` builds via the normal `robot merge` path because its published OWL imports resolve.
- `oto` needed a custom `build_command` because the published ontology imports `http://w3id.org/oto/develop/oto-shared.ttl`, which currently resolves to HTML rather than the shared ontology file. The build step rewrites that import to the raw GitHub artifact before running `robot merge`.
- This does not close #107; it is the first implementation slice.

## Validation
- `uv run pytest tests/test_builder/test_registry.py -q`
- manual `robot merge` smoke test against the upstream `cepo.owl`
- manual `robot merge` smoke test against `oto.ttl` after the import rewrite encoded in the registry entry

Refs #107
