### PR TITLE
Download SQLite databases from the semanticsql CDN instead of S3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Semantic-SQL transforms OWL/RDF ontologies into SQLite databases with standardized SQL views. Pre-built databases for all OBO ontologies are available via S3 (e.g., `https://s3.amazonaws.com/bbop-sqlite/hp.db.gz`).
+Semantic-SQL transforms OWL/RDF ontologies into SQLite databases with standardized SQL views. Pre-built databases for all OBO ontologies are available via the CDN-backed URL (e.g., `https://semanticsql.berkeleybop.io/hp.db.gz`).
 
 ## Key Commands
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ sqlite> SELECT * FROM rdfs_label_statement WHERE value LIKE 'Abnormality of %';
 |HP:0000032|HP:0000032|rdfs:label||Abnormality of male external genitalia|xsd:string||
 
 
-Ready-made SQLite3 builds can also be downloaded for any ontology in [OBO](http://obofoundry.org), using URLs such as https://s3.amazonaws.com/bbop-sqlite/hp.db.gz
+Ready-made SQLite3 builds can also be downloaded for any ontology in [OBO](http://obofoundry.org), using URLs such as https://semanticsql.berkeleybop.io/hp.db.gz
 
 [relation-graph](https://github.com/balhoff/relation-graph/) is used to pre-generate tables of [entailed edges](https://incatools.github.io/semantic-sql/EntailedEdge/). For example,
 all is-a and part-of ancestors of [finger](http://purl.obolibrary.org/obo/UBERON_0002389) in Uberon:
@@ -73,7 +73,7 @@ semsql download obi -o obi.db
 
 Or simply download using URL of the form:
 
-- https://s3.amazonaws.com/bbop-sqlite/hp.db.gz
+- https://semanticsql.berkeleybop.io/hp.db.gz
 
 ## Attaching databases
 

--- a/src/semsql/builder/builder.py
+++ b/src/semsql/builder/builder.py
@@ -18,6 +18,20 @@ from semsql.utils.makefile_utils import makefile_to_string
 
 this_path = Path(__file__).parent
 
+# Base URL for pre-built semantic-sql SQLite databases. This points at a vendor-neutral
+# CloudFront/Cloudflare-fronted location rather than the raw S3 bucket
+# (https://s3.amazonaws.com/bbop-sqlite), reducing S3 egress charges. See
+# https://github.com/INCATools/semantic-sql/issues/110. Override with the environment
+# variable SEMSQL_SQLITE_URL_BASE if you need a different provider or mirror.
+SEMSQL_SQLITE_URL_BASE = os.environ.get(
+    "SEMSQL_SQLITE_URL_BASE", "https://semanticsql.berkeleybop.io"
+)
+
+# The semantic-sql CDN is fronted by Cloudflare, which rejects requests sent with a default
+# programmatic User-Agent (e.g. ``Python-urllib/x.y``) with HTTP 403. We therefore send an
+# explicit User-Agent when downloading databases.
+SEMSQL_DOWNLOAD_HEADERS = {"User-Agent": "semsql"}
+
 
 class DockerConfig:
     """
@@ -93,9 +107,12 @@ def download_obo_sqlite(ontology: str, destination: str):
     :return:
     """
     db = f"{ontology}.db"
-    url = f"https://s3.amazonaws.com/bbop-sqlite/{db}.gz"
+    url = f"{SEMSQL_SQLITE_URL_BASE}/{db}.gz"
     logging.info(f"Downloading from {url}")
-    r = requests.get(url, allow_redirects=True, timeout=3600)
+    r = requests.get(
+        url, allow_redirects=True, timeout=3600, headers=SEMSQL_DOWNLOAD_HEADERS
+    )
+    r.raise_for_status()
     destination_gzip = f"{destination}.gz"
     open(destination_gzip, "wb").write(r.content)
     with gzip.open(destination_gzip, "rb") as f_in:

--- a/tests/test_builder/test_builder.py
+++ b/tests/test_builder/test_builder.py
@@ -1,7 +1,9 @@
+import gzip
 import os
 import tempfile
 import textwrap
 import unittest
+from unittest.mock import MagicMock, patch
 
 from semsql.builder import builder
 from semsql.builder.registry import path_to_ontology_registry
@@ -52,6 +54,34 @@ class TestBuilder(unittest.TestCase):
                 ],
                 steps,
             )
+
+    def test_download_uses_cdn_url_and_user_agent(self):
+        """download_obo_sqlite should hit the vendor-neutral CDN with an explicit User-Agent.
+
+        The CDN is fronted by Cloudflare, which returns HTTP 403 for a default
+        ``Python-urllib`` User-Agent, so the request must set one explicitly.
+        """
+        response = MagicMock()
+        response.content = gzip.compress(b"fake-db-bytes")
+        response.raise_for_status = MagicMock()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            destination = os.path.join(tmpdir, "bfo.db")
+            with patch.object(
+                builder.requests, "get", return_value=response
+            ) as mock_get:
+                builder.download_obo_sqlite("bfo", destination)
+            self.assertEqual(1, mock_get.call_count)
+            url = mock_get.call_args.args[0]
+            self.assertEqual(
+                f"{builder.SEMSQL_SQLITE_URL_BASE}/bfo.db.gz", url
+            )
+            self.assertNotIn("s3.amazonaws.com", url)
+            self.assertEqual(
+                "semsql",
+                mock_get.call_args.kwargs["headers"]["User-Agent"],
+            )
+            with open(destination, "rb") as stream:
+                self.assertEqual(b"fake-db-bytes", stream.read())
 
     def test_get_postprocessing_steps_missing_ontology(self):
         registry_text = textwrap.dedent(


### PR DESCRIPTION
Fixes #110.

## What

`download_obo_sqlite` (the function behind `semsql download`) now fetches pre-built databases from the vendor-neutral CDN `https://semanticsql.berkeleybop.io/{db}.gz` instead of the raw S3 bucket `https://s3.amazonaws.com/bbop-sqlite/{db}.gz`. The CDN is layered behind CloudFront + Cloudflare, which reduces S3 egress charges. This mirrors the OAK-side change in [INCATools/ontology-access-kit#898](https://github.com/INCATools/ontology-access-kit/pull/898), which updated OAK's `sqlite:obo:` selector; this PR covers semantic-sql's own hardcoded URL that #898 called out as a separate follow-up.

## The Cloudflare catch

The CDN's Cloudflare front **rejects the default `Python-urllib/x.y` User-Agent with HTTP 403**. This repo's downloader uses `requests` (whose default `python-requests` UA currently gets through), but to be defensive the request now sends an explicit `User-Agent` header and calls `raise_for_status()` so any future block fails loudly rather than silently writing an error page into the `.db`.

## Changes (split for review)

1. **`builder.py`** — `SEMSQL_SQLITE_URL_BASE` constant (overridable via the `SEMSQL_SQLITE_URL_BASE` env var for mirrors/alternate providers), explicit User-Agent, and `raise_for_status()`.
2. **`test_builder.py`** — mocked unit test asserting the CDN URL is built (not an S3 one) and the User-Agent is sent.
3. **Docs** — `README.md` download URLs and the project overview (`AGENTS.md`, symlinked as `CLAUDE.md`) updated to the CDN.

## Verification

- Downloaded `bfo` end-to-end through the new code path: 1221 statement rows, valid SQLite.
- Confirmed via curl that the CDN returns 403 for the `Python-urllib` UA and 200 for our explicit UA.
- All builder tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)