### PR TITLE
Update gh-action-pypi-publish so PyPI uploads stop failing with 403

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -46,7 +46,6 @@ jobs:
         uv build
 
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.2.2
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
## Summary
- PyPI releases have been failing at the upload step: [v0.4.2](https://github.com/INCATools/semantic-sql/actions/runs/29330376025) and v0.4.1 both died with `403 Forbidden from https://upload.pypi.org/legacy/`.
- The workflow was pinned to `pypa/gh-action-pypi-publish@v1.2.2` (2020), whose bundled twine PyPI no longer accepts.
- Bump to `release/v1` (currently v1.14.0), which uses PyPI's current upload API and matches the major-version pinning style of the other actions in this workflow. Also drop `user: __token__`, which is the default in modern versions.

The existing `pypi_password` API-token secret keeps working unchanged. A follow-up worth considering is switching to [trusted publishing](https://docs.pypi.org/trusted-publishers/), which removes the token entirely, but that needs a one-time configuration on pypi.org by a project maintainer.

## Test plan
- Workflow only fires on `release: created`, so the real test is the next release (or re-publishing the v0.4.2 tag).
- YAML validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)