### PR TITLE
Update ontology registry and S3 deployment metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,15 +233,22 @@ bin/%:
 ### DEPLOY
 
 DATE = $(shell date -u +"%Y-%m-%d")
+S3_CACHE_CONTROL = public, max-age=86400
 
 s3-deploy:
-	aws s3 sync stage s3://bbop-sqlite --acl public-read
+	aws s3 sync stage s3://bbop-sqlite --acl public-read \
+		--cache-control "$(S3_CACHE_CONTROL)" \
+		--content-type application/gzip
 
 s3-version:
-	aws s3 sync stage s3://bbop-sqlite/releases/$(DATE) --acl public-read
+	aws s3 sync stage s3://bbop-sqlite/releases/$(DATE) --acl public-read \
+		--cache-control "$(S3_CACHE_CONTROL)" \
+		--content-type application/gzip
 
 s3-deploy-%: stage/%.db.gz
-	aws s3 cp $< s3://bbop-sqlite/$*.db.gz --acl public-read
+	aws s3 cp $< s3://bbop-sqlite/$*.db.gz --acl public-read \
+		--cache-control "$(S3_CACHE_CONTROL)" \
+		--content-type application/gzip
 
 
 # Test documentation locally

--- a/db/README.md
+++ b/db/README.md
@@ -1,1 +1,0 @@
-# sqlite dbs go here

--- a/ontologies.Makefile
+++ b/ontologies.Makefile
@@ -65,7 +65,7 @@ db/ncit.owl: download/ncit.owl
 
 
 download/fma.owl: STAMP
-	curl -L -s http://sig.biostr.washington.edu/share/downloads/fma/release/latest/fma.owl > $@.tmp
+	curl -L -s http://purl.org/sig/ont/fma.owl > $@.tmp
 	sha256sum -b $@.tmp > $@.sha256
 	mv $@.tmp $@
 
@@ -406,7 +406,7 @@ db/ordo.owl: download/ordo.owl
 
 
 download/gard.owl: STAMP
-	curl -L -s https://github.com/monarch-initiative/mondo-ingest/releases/latest/download/gard.owl > $@.tmp
+	curl -L -s https://github.com/monarch-initiative/gard/releases/latest/download/gard.owl > $@.tmp
 	sha256sum -b $@.tmp > $@.sha256
 	mv $@.tmp $@
 
@@ -864,6 +864,17 @@ download/hcao.owl: STAMP
 .PRECIOUS: download/hcao.owl
 
 db/hcao.owl: download/hcao.owl
+	cp $< $@
+
+
+download/ssbd.owl: STAMP
+	curl -L -s https://raw.githubusercontent.com/openssbd/ssbd-ontology/v20250512-1/ontology/ssbd_integrated.owl > $@.tmp
+	sha256sum -b $@.tmp > $@.sha256
+	mv $@.tmp $@
+
+.PRECIOUS: download/ssbd.owl
+
+db/ssbd.owl: download/ssbd.owl
 	cp $< $@
 
 
@@ -1735,4 +1746,4 @@ download/%.owl: STAMP
 db/%.owl: download/%.owl
 	robot merge -i $< -o $@
 
-EXTRA_ONTOLOGIES = swo chiro pcl chemessence ogco ncit fma maxo foodon chebiplus msio chemrof deb matpo panet phenx pride sosa emi npc modl phenio comploinc hba mba dmba dhba pba bero aio reacto xsmo bcio sio icd10who icd11f ordo gard icd10cm omim mondo-ingest oeo envthes wifire taxslim goldterms sdgio kin metpo d3o biovoices omop comet cco occo iof upa go go-lego go-amigo neo bao orcid ror cpont biolink biopax enanomapper mlo ito chemont molgenie cso obiws biopragmatics-reactome reactome-hs reactome-mm efo hcao hpinternational edam chr sweetAll oboe-core oboe-standards lov schema-dot-org prov dtype vaem qudtunit quantitykind cellosaurus cosmo gist gistBFO fhkb dbpendiaont uberoncm co_324 ppeo interpro pfam hgnc.genegroup hgnc sgd gtdb eccode uniprot uniprot.ptm credit rhea swisslipid drugbank drugcentral complexportal wikipathways pathbank kegg.genome drugmechdb rxnorm vccf ontobiotope nando ecso enigma_context cbo ontie pain como ecosim bervo valuesets micront nmdc_schema mixs kgcl fibo bfo2020 bfo2020_core bfo2020_notime bfo2020_time saref saref4city saref4ener saref4bldg hhearvs sdoho pathgo brick minsysont cmso asmo sulo uco d3fend codamos
+EXTRA_ONTOLOGIES = swo chiro pcl chemessence ogco ncit fma maxo foodon chebiplus msio chemrof deb matpo panet phenx pride sosa emi npc modl phenio comploinc hba mba dmba dhba pba bero aio reacto xsmo bcio sio icd10who icd11f ordo gard icd10cm omim mondo-ingest oeo envthes wifire taxslim goldterms sdgio kin metpo d3o biovoices omop comet cco occo iof upa go go-lego go-amigo neo bao orcid ror cpont biolink biopax enanomapper mlo ito chemont molgenie cso obiws biopragmatics-reactome reactome-hs reactome-mm efo hcao ssbd hpinternational edam chr sweetAll oboe-core oboe-standards lov schema-dot-org prov dtype vaem qudtunit quantitykind cellosaurus cosmo gist gistBFO fhkb dbpendiaont uberoncm co_324 ppeo interpro pfam hgnc.genegroup hgnc sgd gtdb eccode uniprot uniprot.ptm credit rhea swisslipid drugbank drugcentral complexportal wikipathways pathbank kegg.genome drugmechdb rxnorm vccf ontobiotope nando ecso enigma_context cbo ontie pain como ecosim bervo valuesets micront nmdc_schema mixs kgcl fibo bfo2020 bfo2020_core bfo2020_notime bfo2020_time saref saref4city saref4ener saref4bldg hhearvs sdoho pathgo brick minsysont cmso asmo sulo uco d3fend codamos

--- a/src/semsql/builder/prefixes/prefixes.csv
+++ b/src/semsql/builder/prefixes/prefixes.csv
@@ -162,6 +162,8 @@ cyc,http://sw.cyc.com/concept
 OBIws,http://purl.obolibrary.org/obo/OBIws_
 reactome.obo,http://purl.obolibrary.org/obo/reactome_
 reactome.biopax,http://www.reactome.org/biopax/77/48887#
+ssbd,http://ssbd.riken.jp/ontology/
+SSBD,http://metadb.riken.jp/ontology/SSBD/
 chr,http://purl.obolibrary.org/obo/CHR_
 oboe-core,http://ecoinformatics.org/oboe/oboe.1.0/oboe-core.owl#
 oboe-standards,http://ecoinformatics.org/oboe/oboe.1.0/oboe-standards.owl#

--- a/src/semsql/builder/prefixes/prefixes_local.csv
+++ b/src/semsql/builder/prefixes/prefixes_local.csv
@@ -99,6 +99,8 @@ cyc,http://sw.cyc.com/concept
 OBIws,http://purl.obolibrary.org/obo/OBIws_
 reactome.obo,http://purl.obolibrary.org/obo/reactome_
 reactome.biopax,http://www.reactome.org/biopax/77/48887#
+ssbd,http://ssbd.riken.jp/ontology/
+SSBD,http://metadb.riken.jp/ontology/SSBD/
 chr,http://purl.obolibrary.org/obo/CHR_
 oboe-core,http://ecoinformatics.org/oboe/oboe.1.0/oboe-core.owl#
 oboe-standards,http://ecoinformatics.org/oboe/oboe.1.0/oboe-standards.owl#

--- a/src/semsql/builder/registry/ontologies.yaml
+++ b/src/semsql/builder/registry/ontologies.yaml
@@ -42,7 +42,7 @@ ontologies:
     url: http://purl.obolibrary.org/obo/ncit.owl
     build_command: "robot relax -i $< merge -o $@"
   fma:
-    url: http://sig.biostr.washington.edu/share/downloads/fma/release/latest/fma.owl
+    url:  http://purl.org/sig/ont/fma.owl
     prefixmap:
       FMA: http://purl.org/sig/ont/fma/fma
   maxo:
@@ -182,7 +182,7 @@ ontologies:
   ordo:
     url: https://github.com/monarch-initiative/mondo-ingest/releases/latest/download/ordo.owl
   gard:
-    url: https://github.com/monarch-initiative/mondo-ingest/releases/latest/download/gard.owl
+    url: https://github.com/monarch-initiative/gard/releases/latest/download/gard.owl
     prefixmap:
       GARD: http://purl.obolibrary.org/obo/GARD_
   icd10cm:
@@ -380,6 +380,12 @@ ontologies:
     has_imports: true
   hcao:
     url: https://raw.githubusercontent.com/HumanCellAtlas/ontology/master/hcao.owl
+  ssbd:
+    description: SSBD Ontology for interoperable bioimaging metadata
+    url: https://raw.githubusercontent.com/openssbd/ssbd-ontology/v20250512-1/ontology/ssbd_integrated.owl
+    prefixmap:
+      ssbd: http://ssbd.riken.jp/ontology/
+      SSBD: http://metadb.riken.jp/ontology/SSBD/
   hpinternational:
     url:  http://purl.obolibrary.org/obo/hp/hp-international.owl
   edam:


### PR DESCRIPTION
## Summary

- register the SSBD ontology and its two prefix mappings
- update the FMA and GARD download URLs to their maintained locations
- set explicit gzip content type and cache-control metadata for S3 deployments
- remove the obsolete database directory placeholder

## Why

The previous FMA and GARD sources have moved, SSBD needs to be available through the non-OBO ontology registry, and deployed `.db.gz` artifacts should carry stable HTTP metadata for clients and caches.

## Impact

Ontology builds can download FMA, GARD, and SSBD from their current sources. S3-hosted database archives will be served as gzip content with a one-day public cache lifetime.

## Root cause

The registry and generated Makefile still referenced superseded download locations, SSBD had not yet been registered, and the S3 deployment commands did not set object metadata explicitly.

## Validation

- `uv run pytest tests/test_builder/` (7 passed, 2 skipped)
- focused YAML, prefix CSV, and generated Makefile consistency assertions
- `git diff --check origin/main...HEAD`
