### PR TITLE
Add URL migration announcement and update tutorial notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ sqlite> SELECT * FROM rdfs_label_statement WHERE value LIKE 'Abnormality of %';
 
 Ready-made SQLite3 builds can also be downloaded for any ontology in [OBO](http://obofoundry.org), using URLs such as https://semanticsql.berkeleybop.io/hp.db.gz
 
+> **⚠️ URL change:** Pre-built databases are now served from
+> `https://semanticsql.berkeleybop.io/$ONT.db.gz` instead of the legacy
+> `https://s3.amazonaws.com/bbop-sqlite/$ONT.db.gz`.
+> [OAK](https://github.com/INCATools/ontology-access-kit) users are unaffected
+> if running OAK ≥ 0.7.2. If your code fetches the old S3 URL directly, please
+> update it. Note that the new CDN requires a non-default HTTP `User-Agent`
+> header — the default `Python-urllib` agent is blocked by Cloudflare's Browser
+> Integrity Check (see [#115](https://github.com/INCATools/semantic-sql/issues/115)
+> for details). See also [#110](https://github.com/INCATools/semantic-sql/issues/110)
+> (original migration) and [#43](https://github.com/INCATools/semantic-sql/issues/43)
+> (PURL-based URLs).
+
 [relation-graph](https://github.com/balhoff/relation-graph/) is used to pre-generate tables of [entailed edges](https://incatools.github.io/semantic-sql/EntailedEdge/). For example,
 all is-a and part-of ancestors of [finger](http://purl.obolibrary.org/obo/UBERON_0002389) in Uberon:
 

--- a/notebooks/SemanticSQL-Tutorial.ipynb
+++ b/notebooks/SemanticSQL-Tutorial.ipynb
@@ -64,13 +64,13 @@
       "Resolving s3.amazonaws.com (s3.amazonaws.com)... 3.5.16.140\n",
       "Connecting to s3.amazonaws.com (s3.amazonaws.com)|3.5.16.140|:443... connected.\n",
       "HTTP request sent, awaiting response... 304 Not Modified\n",
-      "File ‘cl.db.gz’ not modified on server. Omitting download.\n",
+      "File \u2018cl.db.gz\u2019 not modified on server. Omitting download.\n",
       "\n"
      ]
     }
    ],
    "source": [
-    "!wget -N https://s3.amazonaws.com/bbop-sqlite/cl.db.gz"
+    "!wget -N https://semanticsql.berkeleybop.io/cl.db.gz"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Closes #121.

- **README.md**: Adds a visible callout after the "Ready-made SQLite3 builds" line announcing the migration from `s3.amazonaws.com/bbop-sqlite` to `semanticsql.berkeleybop.io`, noting that OAK >= 0.7.2 users are unaffected, and warning about the CDN User-Agent requirement (Cloudflare Browser Integrity Check). Cross-references #110 (original migration), #115 (external consumer tracking), and #43 (PURL-based URLs).
- **notebooks/SemanticSQL-Tutorial.ipynb**: Updates the `wget` URL from the old S3 path to the new CDN URL.

## Test plan

- [ ] Verify the README renders correctly on GitHub
- [ ] Verify the notebook wget cell uses the new URL
- [ ] Confirm `wget -N https://semanticsql.berkeleybop.io/cl.db.gz` downloads successfully
